### PR TITLE
Fix#3 add method to normalize uv position

### DIFF
--- a/PMXEPlugin536.MaskImageToEdge.Tests/MaskImageToEdge.Tests.csproj
+++ b/PMXEPlugin536.MaskImageToEdge.Tests/MaskImageToEdge.Tests.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1D1BDF08-3981-46CC-9908-167E08E5BEB5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PMXEPlugin536.MaskImageToEdge.Tests</RootNamespace>
+    <AssemblyName>PMXEPlugin536.MaskImageToEdge.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RunnerTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PMXEPlugin536.MaskImageToEdge\MaskImageToEdge.csproj">
+      <Project>{146b94e2-62b3-4ea3-b064-03f576b1a94f}</Project>
+      <Name>MaskImageToEdge</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/PMXEPlugin536.MaskImageToEdge.Tests/RunnerTest.cs
+++ b/PMXEPlugin536.MaskImageToEdge.Tests/RunnerTest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PMXEPlugin536.MaskImageToEdge.Tests {
+    [TestClass]
+    public class Normalize_float_between_0_and_1_Test {
+
+        [TestMethod]
+        public void Normalize_simple_Test() {
+            var privateType = new PrivateType(typeof(Runner));
+            var normarizedVal = privateType.InvokeStatic("normalize", 0.25f);
+            Assert.AreEqual(0.25f, normarizedVal);
+        }
+
+        [TestMethod]
+        public void Normalize_over_1_Test() {
+            var privateType = new PrivateType(typeof(Runner));
+            var normarizedVal = privateType.InvokeStatic("normalize", 1.75f);
+            Assert.AreEqual(0.75f, normarizedVal);
+        }
+
+        [TestMethod]
+        public void Normalize_negative_Test() {
+            var privateType = new PrivateType(typeof(Runner));
+            var normarizedVal = privateType.InvokeStatic("normalize", -1.25f);
+            Assert.AreEqual(0.75f, normarizedVal);
+        }
+
+    }
+}

--- a/PMXEPlugin536.MaskImageToEdge/Runner.cs
+++ b/PMXEPlugin536.MaskImageToEdge/Runner.cs
@@ -57,8 +57,8 @@ namespace PMXEPlugin536.MaskImageToEdge {
                         continue;
                     }
                     var uv = vertex.UV;
-                    int x = (int)Math.Round(uv.U * (bitmap.Width - 1), 0);
-                    int y = (int)Math.Round(uv.V * (bitmap.Height - 1), 0);
+                    int x = (int)Math.Round(normalize(uv.U) * (bitmap.Width - 1), 0);
+                    int y = (int)Math.Round(normalize(uv.V) * (bitmap.Height - 1), 0);
                     var pixel = bitmap.GetPixel(x, y);
                     vertex.EdgeScale = convertRGBtoLuma(pixel.R, pixel.G, pixel.B);
                 }
@@ -71,6 +71,10 @@ namespace PMXEPlugin536.MaskImageToEdge {
             } catch (Exception ex) {
                 MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
+        }
+
+        private static float normalize(float value) {
+            return value - (float)Math.Floor(value);
         }
 
         private static void backupModelFile(String filepath,

--- a/PMXEPlugin536.sln
+++ b/PMXEPlugin536.sln
@@ -10,6 +10,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaskImageToEdge.Tests", "PMXEPlugin536.MaskImageToEdge.Tests\MaskImageToEdge.Tests.csproj", "{1D1BDF08-3981-46CC-9908-167E08E5BEB5}"
+	ProjectSection(ProjectDependencies) = postProject
+		{146B94E2-62B3-4EA3-B064-03F576B1A94F} = {146B94E2-62B3-4EA3-B064-03F576B1A94F}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +31,14 @@ Global
 		{146B94E2-62B3-4EA3-B064-03F576B1A94F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{146B94E2-62B3-4EA3-B064-03F576B1A94F}.Release|x64.ActiveCfg = Release|Any CPU
 		{146B94E2-62B3-4EA3-B064-03F576B1A94F}.Release|x64.Build.0 = Release|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Debug|x64.Build.0 = Debug|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Release|x64.ActiveCfg = Release|Any CPU
+		{1D1BDF08-3981-46CC-9908-167E08E5BEB5}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fix #3 UV座標を係数として使用する前に、正規化するメソッドを追加しました。また、そのメソッドの動作仕様を確定させるためUnitTestも追加しました。